### PR TITLE
Replaced int32 usage with uint32 according to SFA spec.

### DIFF
--- a/lib/geometry.js
+++ b/lib/geometry.js
@@ -65,7 +65,7 @@ Geometry._parseWkb = function (value) {
 
     binaryReader.isBigEndian = !binaryReader.readInt8();
 
-    var geometryType = binaryReader.readInt32();
+    var geometryType = binaryReader.readUInt32();
 
     switch (geometryType) {
     case Types.wkb.Point:

--- a/lib/geometrycollection.js
+++ b/lib/geometrycollection.js
@@ -28,7 +28,7 @@ GeometryCollection._parseWkt = function (value) {
 GeometryCollection._parseWkb = function (value) {
     var geometryCollection = new GeometryCollection();
 
-    var geometryCount = value.readInt32();
+    var geometryCount = value.readUInt32();
 
     for (var i = 0; i < geometryCount; i++)
         geometryCollection.geometries.push(Geometry.parse(value));
@@ -56,8 +56,8 @@ GeometryCollection.prototype.toWkb = function () {
 
     wkb.writeInt8(1);
 
-    wkb.writeInt32LE(Types.wkb.GeometryCollection);
-    wkb.writeInt32LE(this.geometries.length);
+    wkb.writeUInt32LE(Types.wkb.GeometryCollection);
+    wkb.writeUInt32LE(this.geometries.length);
 
     for (var i = 0; i < this.geometries.length; i++)
         wkb.writeBuffer(this.geometries[i].toWkb());

--- a/lib/linestring.js
+++ b/lib/linestring.js
@@ -24,7 +24,7 @@ LineString._parseWkt = function (value) {
 LineString._parseWkb = function (value) {
     var lineString = new LineString();
 
-    var pointCount = value.readInt32();
+    var pointCount = value.readUInt32();
 
     for (var i = 0; i < pointCount; i++)
         lineString.points.push(new Point(value.readDouble(), value.readDouble()));
@@ -56,8 +56,8 @@ LineString.prototype.toWkb = function () {
 
     wkb.writeInt8(1);
 
-    wkb.writeInt32LE(Types.wkb.LineString);
-    wkb.writeInt32LE(this.points.length);
+    wkb.writeUInt32LE(Types.wkb.LineString);
+    wkb.writeUInt32LE(this.points.length);
 
     for (var i = 0; i < this.points.length; i++) {
         wkb.writeDoubleLE(this.points[i].x);

--- a/lib/multilinestring.js
+++ b/lib/multilinestring.js
@@ -31,7 +31,7 @@ MultiLineString._parseWkt = function (value) {
 MultiLineString._parseWkb = function (value) {
     var multiLineString = new MultiLineString();
 
-    var pointCount = value.readInt32();
+    var pointCount = value.readUInt32();
 
     for (var i = 0; i < pointCount; i++)
         multiLineString.lineStrings.push(Geometry.parse(value));
@@ -59,8 +59,8 @@ MultiLineString.prototype.toWkb = function () {
 
     wkb.writeInt8(1);
 
-    wkb.writeInt32LE(Types.wkb.MultiLineString);
-    wkb.writeInt32LE(this.lineStrings.length);
+    wkb.writeUInt32LE(Types.wkb.MultiLineString);
+    wkb.writeUInt32LE(this.lineStrings.length);
 
     for (var i = 0; i < this.lineStrings.length; i++)
         wkb.writeBuffer(this.lineStrings[i].toWkb());

--- a/lib/multipoint.js
+++ b/lib/multipoint.js
@@ -24,7 +24,7 @@ MultiPoint._parseWkt = function (value) {
 MultiPoint._parseWkb = function (value) {
     var multiPoint = new MultiPoint();
 
-    var pointCount = value.readInt32();
+    var pointCount = value.readUInt32();
 
     for (var i = 0; i < pointCount; i++)
         multiPoint.points.push(Geometry.parse(value));
@@ -52,8 +52,8 @@ MultiPoint.prototype.toWkb = function () {
 
     wkb.writeInt8(1);
 
-    wkb.writeInt32LE(Types.wkb.MultiPoint);
-    wkb.writeInt32LE(this.points.length);
+    wkb.writeUInt32LE(Types.wkb.MultiPoint);
+    wkb.writeUInt32LE(this.points.length);
 
     for (var i = 0; i < this.points.length; i++)
         wkb.writeBuffer(this.points[i].toWkb());

--- a/lib/multipolygon.js
+++ b/lib/multipolygon.js
@@ -46,7 +46,7 @@ MultiPolygon._parseWkt = function (value) {
 MultiPolygon._parseWkb = function (value) {
     var multiPolygon = new MultiPolygon();
 
-    var polygonCount = value.readInt32();
+    var polygonCount = value.readUInt32();
 
     for (var i = 0; i < polygonCount; i++)
         multiPolygon.polygons.push(Geometry.parse(value));
@@ -74,8 +74,8 @@ MultiPolygon.prototype.toWkb = function () {
 
     wkb.writeInt8(1);
 
-    wkb.writeInt32LE(Types.wkb.MultiPolygon);
-    wkb.writeInt32LE(this.polygons.length);
+    wkb.writeUInt32LE(Types.wkb.MultiPolygon);
+    wkb.writeUInt32LE(this.polygons.length);
 
     for (var i = 0; i < this.polygons.length; i++)
         wkb.writeBuffer(this.polygons[i].toWkb());

--- a/lib/point.js
+++ b/lib/point.js
@@ -43,11 +43,11 @@ Point.prototype.toWkb = function () {
     wkb.writeInt8(1);
 
     if (typeof this.x === 'undefined' && typeof this.y === 'undefined') {
-        wkb.writeInt32LE(Types.wkb.MultiPoint);
-        wkb.writeInt32LE(0);
+        wkb.writeUInt32LE(Types.wkb.MultiPoint);
+        wkb.writeUInt32LE(0);
     }
     else {
-        wkb.writeInt32LE(Types.wkb.Point);
+        wkb.writeUInt32LE(Types.wkb.Point);
         wkb.writeDoubleLE(this.x);
         wkb.writeDoubleLE(this.y);
     }

--- a/lib/polygon.js
+++ b/lib/polygon.js
@@ -35,10 +35,10 @@ Polygon._parseWkt = function (value) {
 Polygon._parseWkb = function (value) {
     var polygon = new Polygon();
 
-    var ringCount = value.readInt32();
+    var ringCount = value.readUInt32();
 
     if (ringCount > 0) {
-        var exteriorRingCount = value.readInt32();
+        var exteriorRingCount = value.readUInt32();
 
         for (var i = 0; i < exteriorRingCount; i++)
             polygon.exteriorRing.push(new Point(value.readDouble(), value.readDouble()));
@@ -46,7 +46,7 @@ Polygon._parseWkb = function (value) {
         for (i = 1; i < ringCount; i++) {
             var interiorRing = [];
 
-            var interiorRingCount = value.readInt32();
+            var interiorRingCount = value.readUInt32();
 
             for (var j = 0; j < interiorRingCount; j++)
                 interiorRing.push(new Point(value.readDouble(), value.readDouble()));
@@ -95,14 +95,14 @@ Polygon.prototype.toWkb = function () {
 
     wkb.writeInt8(1);
 
-    wkb.writeInt32LE(Types.wkb.Polygon);
+    wkb.writeUInt32LE(Types.wkb.Polygon);
 
     if (this.exteriorRing.length > 0) {
-        wkb.writeInt32LE(1 + this.interiorRings.length);
-        wkb.writeInt32LE(this.exteriorRing.length);
+        wkb.writeUInt32LE(1 + this.interiorRings.length);
+        wkb.writeUInt32LE(this.exteriorRing.length);
     }
     else {
-        wkb.writeInt32LE(0);
+        wkb.writeUInt32LE(0);
     }
 
     for (var i = 0; i < this.exteriorRing.length; i++) {
@@ -111,7 +111,7 @@ Polygon.prototype.toWkb = function () {
     }
 
     for (i = 0; i < this.interiorRings.length; i++) {
-        wkb.writeInt32LE(this.interiorRings[i].length);
+        wkb.writeUInt32LE(this.interiorRings[i].length);
 
         for (var j = 0; j < this.interiorRings[i].length; j++) {
             wkb.writeDoubleLE(this.interiorRings[i][j].x);


### PR DESCRIPTION
According to http://www.opengeospatial.org/standards/sfa, all integer fields in WKB should be **un**signed; this corrects the code to match that.
