### PR TITLE
fixed Buffer constructor deprecation

### DIFF
--- a/lib/binarywriter.js
+++ b/lib/binarywriter.js
@@ -1,7 +1,7 @@
 module.exports = BinaryWriter;
 
 function BinaryWriter(size, allowResize) {
-    this.buffer = new Buffer(size);
+    this.buffer = new Buffer.alloc(size);
     this.position = 0;
     this.allowResize = allowResize;
 }
@@ -54,7 +54,7 @@ BinaryWriter.prototype.writeVarInt = function (value) {
 BinaryWriter.prototype.ensureSize = function (size) {
     if (this.buffer.length < this.position + size) {
         if (this.allowResize) {
-            var tempBuffer = new Buffer(this.position + size);
+            var tempBuffer = new Buffer.alloc(this.position + size);
             this.buffer.copy(tempBuffer, 0, 0, this.buffer.length);
             this.buffer = tempBuffer;
         }


### PR DESCRIPTION
Quick PR replacing deprecated Buffer constructor with Buffer.alloc() in binary writer.
All 1369 test are passing.